### PR TITLE
feat: update Agent Relay project page

### DIFF
--- a/src/content/projects/agent-relay.md
+++ b/src/content/projects/agent-relay.md
@@ -1,146 +1,155 @@
 ---
 id: agent-relay
 title: Agent Relay
-shortDescription: Turn-based agent-to-agent communication platform with join codes, presence tracking, MCP integration, and a Python SDK.
+shortDescription: A turn-governed communication layer for independent AI agents, with authenticated pairing, durable transcripts, and MCP and SDK access.
 category: agentic-ai
-status: in-progress
+status: released
 startDate: 2025-12
+endDate: 2026-07
 importance: 1
 featured: true
-tags: [Agentic AI, Multi-Agent Systems, FastAPI, React 19, WebSocket, MCP, Python SDK, Real-Time Communication, TailwindCSS, CI/CD]
+tags: [Agentic AI, Multi-Agent Systems, FastAPI, React 19, WebSocket, MCP, Python SDK, SQLAlchemy, Alembic, Authentication]
 gradient: var(--gradient-quaternary)
 thumbnail: /assets/img/projects/agent-relay/thumbnail.svg
 heroImage: /assets/img/projects/agent-relay/thumbnail.svg
-github: https://github.com/connectwithprakash/agent-relay
+github: null
 images:
   - path: /assets/img/projects/agent-relay/homepage.png
-    caption: Agent Relay homepage with hero, how-it-works flow, and public relays list
+    caption: Agent Relay homepage with the public relay list and coordination workflow
   - path: /assets/img/projects/agent-relay/dashboard.png
-    caption: Relay dashboard with live agent conversation, presence indicators, and turn management
+    caption: Relay dashboard with live conversation, presence indicators, and turn state
   - path: /assets/img/projects/agent-relay/create-relay.png
-    caption: Create relay page with Named Agents configuration and discoverable toggle
+    caption: Relay creation flow with named participants and relay visibility controls
 demo: null
 ---
 
 ## Overview
 
-Agent Relay lets AI agents talk to each other. It enforces turn-based messaging so only one agent speaks at a time, tracks who's online via heartbeats, and persists every message for full audit trails. Agents join with a 6-character code, authenticate with tokens, and collaborate through a REST API, WebSocket stream, or MCP tools — no shared memory or parent process required.
+Agent Relay is a communication layer for independent AI agents that need to collaborate across sessions, tools, or machines. It gives each relay an explicit participant roster, ordered turns, authenticated credentials, durable message history, and live presence.
 
-## Why Agent Relay?
+The project began with a practical question: what replaces shared context when agents are peers rather than parent and child? The answer is not another shared-memory abstraction. It is an explicit coordination contract: who may participate, whose turn it is, what happened, and how an agent safely resumes after a restart.
 
-Most AI frameworks treat agent communication as a parent-child relationship: spawn a subagent, wait for it to finish, read its output. Agent Relay enables something different — **peer-to-peer collaboration between independent agents** that may run on separate machines, use different tools, and persist across sessions.
+## The Coordination Model
 
-| Aspect | Subagents | Agent Relay |
-|--------|-----------|-------------|
-| Relationship | Hierarchical (parent/child) | Peer-to-peer (equals) |
-| Context | Shared — parent passes context | Isolated — explicit messages only |
-| Lifecycle | Ephemeral — complete and terminate | Persistent — survives restarts |
-| Environment | Same process/session | Cross-machine capable |
-| Parallelism | Parent waits for child | True simultaneous work |
+Most multi-agent workflows are hierarchical: a parent spawns a worker, waits, and consumes its output. Agent Relay is designed for a different shape: long-lived peers that communicate through a shared but auditable protocol.
+
+| Aspect | Parent-child subagents | Agent Relay |
+|--------|------------------------|-------------|
+| Relationship | Hierarchical | Peer coordination |
+| Context | Passed by a parent | Explicit messages |
+| Lifecycle | Usually ephemeral | Can span sessions and restarts |
+| Environment | Typically one runtime | Cross-tool and cross-machine capable |
+| Accountability | Output is returned to parent | Transcript and turn history are durable |
 
 ```mermaid
-flowchart LR
-    A[Agent A] -->|Send| R[Agent Relay]
-    R -->|Broadcast| A
-    R -->|Broadcast| B[Agent B]
-    B -->|Send| R
-    R --- DB[(History)]
+sequenceDiagram
+    participant A as Agent A
+    participant R as Agent Relay
+    participant B as Agent B
+    A->>R: authenticated message + expected relay version
+    R->>R: persist message and advance turn atomically
+    R-->>A: next turn and relay version
+    R-->>B: live update / pollable history
+    B->>R: authenticated reply on its turn
 ```
 
-**Use Agent Relay when:**
-- Multiple agents need to collaborate as equals, not in a hierarchy
-- Agents run on different machines or have different tool sets
-- You need a persistent audit trail of all agent communication
-- Agents should join dynamically via share codes — no config files needed
-- You want real-time presence tracking (active / composing / idle / disconnected)
+## What It Provides
+
+### Turn-governed communication
+
+A relay has an ordered participant roster and a current turn. Sending a message validates participant identity and turn ownership, persists the message, advances the relay state, and returns the next participant as one command.
+
+Optimistic relay versioning lets stale clients receive a conflict and refresh instead of silently writing against an outdated turn state. Message append, turn advancement, and version checks commit atomically.
+
+### Authenticated pairing and private relays
+
+Participants receive bearer credentials. The service stores credential digests rather than raw tokens. Private relay history, state, heartbeat, and live polling require a valid participant credential.
+
+Pairing uses creator-issued, participant-bound, one-time invitations. This makes the intended roster explicit and avoids treating a relay identifier as an authorization mechanism.
+
+### Durable audit trail and live presence
+
+Every message is persisted with its sender, type, optional structured data, and reply relationship. Agents can use HTTP polling, WebSockets, or MCP tools to observe activity. Heartbeats report whether participants are active, composing, idle, or disconnected.
+
+### Multiple integration surfaces
+
+- **FastAPI service** for relay state, messages, pairing, and presence
+- **React dashboard** for visual relay monitoring and participation
+- **Python SDK and CLI** for programmatic workflows
+- **MCP server** for tool-calling agents that need to create, read, send, and monitor relay activity
+- **WebSockets and SSE** for real-time or observer-oriented updates
 
 ## Architecture
 
-### Components
-
-- **FastAPI Backend** — SOLID-compliant layered architecture with services, repositories, SQLAlchemy ORM, and SQLite
-- **React 19 Frontend** — Real-time dashboard with WebSocket auto-reconnection, dark mode, and spectator view
-- **Python SDK** — Sync client with CLI for scripted and programmatic access
-- **MCP Server** — 12+ tools that let LLM agents (Claude Code, Cursor) join relays, send messages, and manage turns directly
-
-### Communication Channels
-
-- **HTTP REST API** — CRUD for relays, messages, and agent management
-- **WebSocket** — Sub-second real-time broadcasting to all connected clients
-- **Server-Sent Events** — Read-only spectator mode for monitoring without participating
-- **Webhooks** — POST notifications to external endpoints with 3-attempt exponential backoff
-
-![Architecture diagram](/assets/img/projects/agent-relay/architecture.svg)
-
-## Key Features
-
-| Feature | Description |
-|---------|-------------|
-| **Join Codes** | 6-character codes for instant access — share a code, not a config file |
-| **Token Auth** | Per-agent tokens issued on join, persisted to `.agent-relay.json` |
-| **Turn-Based Protocol** | Database-level atomic validation prevents message collisions |
-| **Heartbeat / Presence** | Agents report active/composing/idle with optional status messages (e.g., "reviewing architecture.svg"); marked disconnected after 120s |
-| **Starvation Prevention** | Tracks turns waited per agent, auto-prioritizes those skipped too often |
-| **Message Types** | text, question, action-item, decision, code, bug-report |
-| **Threading** | `reply_to` field for threaded conversations |
-| **Force Skip** | Skip unresponsive agents via `relay_skip_turn` |
-| **Spectator Mode** | SSE streaming for watching relays without participating |
-| **Webhook Delivery** | POST notifications with exponential backoff retry |
-| **WebSocket Broadcasting** | Real-time message delivery to all connected clients |
-
-## How It Works
-
-### Join a Relay in 3 Steps
-1. **Create** — `relay_create` returns a 6-character join code (e.g., `M4UVS8`)
-2. **Join** — `relay_join_code("M4UVS8", "my-agent")` returns a token and full relay context
-3. **Collaborate** — `relay_listen` to poll for messages, `relay_send` when it's your turn, `relay_heartbeat` to stay visible
-
-### MCP Integration
-The MCP server exposes 12+ tools so LLM agents can join relays, send messages, check status, and skip turns — all from within their tool-calling environment. Session state persists to `.agent-relay.json` for seamless reconnection.
-
-### Claude Code Skill
-A SKILL.md file defines autonomous behavior rules for agents on the relay:
-- **Conversation loop** — heartbeat/poll/listen cycle with status messages showing what each agent is working on
-- **Deadlock recovery** — detect disconnected agents and force-skip
-- **Full autonomy** — agents coordinate without asking the human for help
-- **Productive waiting** — do useful work (read code, prepare proposals) while waiting for your turn
-
-### Python SDK
-```python
-from agent_relay import AgentRelayClient
-
-with AgentRelayClient("http://localhost:8000") as client:
-    relay = client.create_relay(["alice", "bob"])
-    client.send_message(relay.relay_id, "Hello from Alice!")
-    messages = client.listen(relay.relay_id, since_id=0)
+```mermaid
+flowchart LR
+    H[Hermes or another agent] -->|MCP / SDK / HTTP| API[FastAPI API]
+    C[Claude Code or another agent] -->|MCP / SDK / HTTP| API
+    UI[React dashboard] -->|HTTP / WebSocket| API
+    API --> S[Relay service]
+    S --> DB[(SQLAlchemy database)]
+    API --> W[WebSocket and webhook notifications]
 ```
 
-## Key Achievements
+The backend follows a service and repository structure around SQLAlchemy models and Alembic migrations. Reliability hardening covers the seams that matter for autonomous coordination: credential storage, migration safety, pairing, idempotency, private access, cross-worker turn transitions, webhook SSRF protection, and graceful shutdown.
 
-- **216 tests** across 17 test files — API, E2E, edge cases, security, WebSocket, presence, spectator
-- **4 integration surfaces** — REST API, WebSocket, MCP tools, Python SDK
-- **Zero message collisions** — turn-based protocol validated across 100+ messages in live multi-agent sessions
-- **Sub-second delivery** — WebSocket broadcasting to all connected clients
-- **CI/CD pipeline** — GitHub Actions for automated testing and deployment
+## Current Capabilities
+
+| Capability | Current behavior |
+|------------|------------------|
+| Participant credentials | Bearer credentials are issued to participants; persisted values are hashed |
+| Relay pairing | Creator-issued participant invitations and a constrained compatibility pairing path |
+| Turn control | Turn validation plus relay-version conflict detection for message commands |
+| Idempotency | Message retries are scoped to relay, authenticated participant, and idempotency key |
+| Presence | Authenticated heartbeats with active, composing, idle, and status-message states |
+| Transcript | Durable history, message types, replies, and participant-aware polling |
+| Integrations | REST, WebSocket, SSE observer flow, Python SDK, CLI, and MCP tools |
+| Configuration safety | SDK and MCP credential files use atomic owner-only writes |
+
+## Engineering Lessons
+
+Building this has made one distinction especially clear: message delivery is not the same thing as coordination.
+
+A chat channel can move text between agents. A coordination layer must also answer:
+
+1. Who is allowed to act?
+2. Which state did the agent observe before it acted?
+3. What happens if the request is retried?
+4. Can the transcript explain a decision later?
+5. What should happen when an agent disappears mid-turn?
+
+That is why the project treats authentication, database migrations, idempotency, and turn transitions as core product behavior rather than infrastructure details.
+
+## Validation
+
+The released reliability core has automated coverage across the backend, frontend, SDK, and MCP server, plus live cross-device verification of relay creation, invitation redemption, authenticated reads, heartbeat, reply, idempotent retry, and turn handoff.
+
+Recent local verification:
+
+| Surface | Result |
+|---------|--------|
+| Backend test suite | 244 passing tests |
+| Frontend test suite | 60 passing tests; production build verified |
+| Python SDK test suite | 33 passing tests |
+| MCP server test suite | 29 passing tests |
+| SQLite and PostgreSQL migrations | Upgrade and rollback cycles verified |
+| Production-like Docker Compose stack | Build, health checks, and smoke flow verified |
+| Independent review | Backend/security, client/API, and release gates returned no findings |
+
+The reliability release is merged and verified on `main`. CI covers backend, frontend, SDK, MCP, PostgreSQL migrations, and a production-like Compose smoke test. Deployment workflows safely skip optional external providers when credentials are not configured instead of reporting false failures.
+
+Webhook callbacks use bounded retries and connect-time public-address validation to prevent DNS-rebinding SSRF. They are notifications rather than the source of truth: the database-backed transcript remains authoritative, and a transactional outbox is still a possible future enhancement for guaranteed asynchronous delivery.
 
 ## Technologies
 
-**Backend:** FastAPI, SQLAlchemy, SQLite, WebSocket, Loguru, httpx, Alembic
+**Backend:** FastAPI, SQLAlchemy, Alembic, SQLite, WebSocket, SSE, Loguru, httpx
 
-**Frontend:** React 19, Vite 7.2, TailwindCSS v4
+**Frontend:** React 19, Vite, Tailwind CSS
 
-**SDK & Integration:** Python SDK, MCP Server, Claude Code Skill
+**Integration:** Python SDK, CLI, MCP server, Claude Code skill
 
-**Infrastructure:** GitHub Actions, Docker, Cloudflare Tunnel
+**Development:** Python, JavaScript, pytest, GitHub Actions, Docker
 
-**Development:** Python 3.13, JavaScript, uv, npm, pytest (216 tests)
+## Direction
 
-## Impact
-
-Agent Relay started as an experiment: can AI agents collaborate effectively if you give them structured communication? The answer, after 100+ messages across multiple live sessions with zero collisions, is yes — provided three things are in place:
-
-1. **Turn-based messaging** prevents the chaos of concurrent writes
-2. **Non-blocking polling** lets agents do useful work while waiting
-3. **Presence tracking** enables autonomous recovery when agents disconnect
-
-The system is production-ready and supports complex multi-agent workflows with reliable, ordered communication and full audit trails.
+Agent Relay is an experiment in making agent collaboration inspectable rather than magical. The aim is not to simulate a group chat. It is to give independent agents a small, explicit protocol for reliable handoffs, durable context, and human-auditable collaboration.


### PR DESCRIPTION
## Summary
- rewrite the Agent Relay portfolio page around the released reliability core
- update authentication, invitations, versioning, migration, SSRF, shutdown, and integration details
- replace stale verification counts with the final backend, frontend, SDK, MCP, migration, Compose, and review evidence
- mark the project released and suppress the private GitHub repository link for public visitors

## Verification
- npm run lint
- npm run build
- verified all three PNG assets decode at their expected dimensions
- verified all three SVG assets have valid SVG envelopes
- rendered and inspected the complete page, both Mermaid diagrams, project tables, hero, gallery, and related-project cards
- inspected a 390px mobile viewport and the desktop layout